### PR TITLE
Fix legend widget cursor navigation key bindings (C-b & C-f)

### DIFF
--- a/src/widget_legend.rs
+++ b/src/widget_legend.rs
@@ -36,10 +36,10 @@ impl LegendWidget {
                 canvas.drawl(Token::new("| (↓)        [C-n]"));
             }
             if tree.can_cursor_left() {
-                canvas.drawl(Token::new("| (←)        [C-f]"));
+                canvas.drawl(Token::new("| (←)        [C-b]"));
             }
             if tree.can_cursor_right() {
-                canvas.drawl(Token::new("| (→)        [C-b]"));
+                canvas.drawl(Token::new("| (→)        [C-f]"));
             }
             if tree.can_toggle() {
                 canvas.drawl(Token::new("| (t)oggle   [TAB]"));


### PR DESCRIPTION
ショートカット説明の C-b, C-f の説明（矢印方向）が逆だったので修正しました。

手元での動作確認では問題なかったです。