### PR TITLE
Fix non-ASCII filename handling

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -384,14 +384,11 @@ impl FileDiff {
             return Ok(None);
         };
 
-        let path = if line.starts_with("diff --git a/") {
-            let path = line["diff --git a/".len()..].split(' ').next().or_fail()?;
+        let path = if let Some(line) = line.strip_prefix("diff --git a/") {
+            let path = line.split(' ').next().or_fail()?;
             PathBuf::from(path)
-        } else if line.starts_with("diff --git \"a/") {
-            let path = line["diff --git \"a/".len()..]
-                .split("\" ")
-                .next()
-                .or_fail()?;
+        } else if let Some(line) = line.strip_prefix("diff --git \"a/") {
+            let path = line.split("\" ").next().or_fail()?;
             git::parse_escaped_path(path).or_fail()?
         } else {
             return Err(orfail::Failure::new(format!(

--- a/src/git.rs
+++ b/src/git.rs
@@ -52,7 +52,7 @@ pub fn unstaged_and_staged_diffs() -> orfail::Result<(Diff, Diff)> {
                     .and_then(|output| {
                         output
                             .lines()
-                            .map(|s| parse_maybe_escaped_path(s))
+                            .map(parse_maybe_escaped_path)
                             .collect::<orfail::Result<Vec<_>>>()
                     })
             });

--- a/src/git.rs
+++ b/src/git.rs
@@ -49,7 +49,12 @@ pub fn unstaged_and_staged_diffs() -> orfail::Result<(Diff, Diff)> {
             let untracked_files_handle = s.spawn(|| {
                 call(&["ls-files", "--others", "--exclude-standard"], true)
                     .or_fail()
-                    .map(|output| output.lines().map(|s| s.to_owned()).collect::<Vec<_>>())
+                    .and_then(|output| {
+                        output
+                            .lines()
+                            .map(|s| parse_maybe_escaped_path(s))
+                            .collect::<orfail::Result<Vec<_>>>()
+                    })
             });
 
             let unstaged_diff = unstaged_diff_handle
@@ -73,7 +78,8 @@ pub fn unstaged_and_staged_diffs() -> orfail::Result<(Diff, Diff)> {
         let mut handles = Vec::new();
         for path in &untracked_files {
             handles.push(s.spawn(move || {
-                let content = std::fs::read(path).or_fail()?;
+                let content = std::fs::read(path)
+                    .or_fail_with(|e| format!("failed to read file {:?}: {e}", path.display()))?;
                 if std::str::from_utf8(&content).is_ok() {
                     let diff = new_file_diff(path, false).or_fail()?;
                     FileDiff::from_str(&diff).or_fail()
@@ -177,6 +183,38 @@ fn call_with_input(args: &[&str], input: &str) -> orfail::Result<String> {
     String::from_utf8(output.stdout).or_fail()
 }
 
+fn parse_maybe_escaped_path(s: &str) -> orfail::Result<PathBuf> {
+    if !s.starts_with('"') {
+        return Ok(PathBuf::from(s));
+    }
+
+    let mut bytes = Vec::new();
+    let mut chars = s.trim_matches('"').chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            bytes.push(c as u8);
+            continue;
+        }
+
+        let c = chars.next().or_fail()?;
+        if !c.is_ascii_digit() {
+            bytes.push(c as u8);
+            continue;
+        }
+
+        let mut num = String::with_capacity(3);
+        num.push(c);
+        num.push(chars.next().or_fail()?);
+        num.push(chars.next().or_fail()?);
+
+        let b = u8::from_str_radix(&num, 8)
+            .or_fail_with(|e| format!("invalid number {num:?}: error={e}, input={s}"))?;
+        bytes.push(b);
+    }
+    let path = String::from_utf8(bytes).or_fail()?;
+    Ok(PathBuf::from(&path))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -195,6 +233,24 @@ mod tests {
         // Now, `dir` is a Git directory.
         assert!(is_available());
 
+        Ok(())
+    }
+
+    #[test]
+    fn parse_maybe_escaped_path_works() -> orfail::Result<()> {
+        assert_eq!(
+            parse_maybe_escaped_path("foo.txt").or_fail()?,
+            PathBuf::from("foo.txt")
+        );
+        assert_eq!(
+            parse_maybe_escaped_path(r#""\343\201\202\343\201\204\343\201\206.txt""#).or_fail()?,
+            PathBuf::from("あいう.txt")
+        );
+        assert_eq!(
+            parse_maybe_escaped_path(r#""\343\201\202\\t\343\201\204a\343\201\206.txt""#)
+                .or_fail()?,
+            PathBuf::from("あ\\tいaう.txt")
+        );
         Ok(())
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -183,13 +183,9 @@ fn call_with_input(args: &[&str], input: &str) -> orfail::Result<String> {
     String::from_utf8(output.stdout).or_fail()
 }
 
-fn parse_maybe_escaped_path(s: &str) -> orfail::Result<PathBuf> {
-    if !s.starts_with('"') {
-        return Ok(PathBuf::from(s));
-    }
-
+pub fn parse_escaped_path(s: &str) -> orfail::Result<PathBuf> {
     let mut bytes = Vec::new();
-    let mut chars = s.trim_matches('"').chars();
+    let mut chars = s.chars();
     while let Some(c) = chars.next() {
         if c != '\\' {
             bytes.push(c as u8);
@@ -213,6 +209,14 @@ fn parse_maybe_escaped_path(s: &str) -> orfail::Result<PathBuf> {
     }
     let path = String::from_utf8(bytes).or_fail()?;
     Ok(PathBuf::from(&path))
+}
+
+fn parse_maybe_escaped_path(s: &str) -> orfail::Result<PathBuf> {
+    if !s.starts_with('"') {
+        return Ok(PathBuf::from(s));
+    }
+
+    parse_escaped_path(s.trim_matches('"')).or_fail()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pull request includes several changes to improve the handling of file paths in the `src/diff.rs` and `src/git.rs` files. The most important changes include adding support for escaped paths, improving error handling, and adding relevant tests.

Improvements to path handling:

* [`src/diff.rs`](diffhunk://#diff-25b61929ffc58aa6b4baa8b06a41448eb83835e05c325863e58df00ed841b2d4L387-R397): Modified the `FileDiff` implementation to handle escaped paths in git diff lines.

Error handling improvements:

* [`src/git.rs`](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5L76-R82): Enhanced the error message when reading files to include the file path and the specific error encountered.

New functions for path parsing:

* [`src/git.rs`](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5R186-R221): Added `parse_escaped_path` and `parse_maybe_escaped_path` functions to handle escaped paths and convert them to `PathBuf`.

Tests for new path parsing functions:

* [`src/git.rs`](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5R242-R259): Added a test for the `parse_maybe_escaped_path` function to ensure it correctly parses both regular and escaped paths.