### PR TITLE
Fix a bug where line discarding might fail.

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -90,7 +90,7 @@ impl ChunkDiff {
             .count()
     }
 
-    pub fn get_line_chunk(&self, index: usize, stage: bool) -> Option<Self> {
+    pub fn get_line_chunk(&self, index: usize, reverse: bool) -> Option<Self> {
         if index >= self.lines.len() {
             return None;
         }
@@ -103,10 +103,10 @@ impl ChunkDiff {
             }
 
             match line {
-                LineDiff::Old(s) if stage => {
+                LineDiff::Old(s) if !reverse => {
                     lines.push(LineDiff::Both(s.clone()));
                 }
-                LineDiff::New(s) if !stage => {
+                LineDiff::New(s) if reverse => {
                     lines.push(LineDiff::Both(s.clone()));
                 }
                 LineDiff::Both(_) => {
@@ -116,7 +116,7 @@ impl ChunkDiff {
             }
         }
 
-        let start = if stage {
+        let start = if !reverse {
             self.old_start_line_number
         } else {
             self.new_start_line_number

--- a/src/widget_diff_tree.rs
+++ b/src/widget_diff_tree.rs
@@ -462,7 +462,7 @@ impl DiffTreeNode {
     }
 
     fn stage(&self, cursor: &Cursor, diff: &Diff) -> orfail::Result<()> {
-        let diff = self.get_diff(cursor, diff, true).or_fail()?;
+        let diff = self.get_diff(cursor, diff, false).or_fail()?;
         git::stage(&diff).or_fail()?;
         Ok(())
     }
@@ -474,12 +474,12 @@ impl DiffTreeNode {
     }
 
     fn unstage(&self, cursor: &Cursor, diff: &Diff) -> orfail::Result<()> {
-        let diff = self.get_diff(cursor, diff, false).or_fail()?;
+        let diff = self.get_diff(cursor, diff, true).or_fail()?;
         git::unstage(&diff).or_fail()?;
         Ok(())
     }
 
-    fn get_diff(&self, cursor: &Cursor, diff: &Diff, stage: bool) -> orfail::Result<Diff> {
+    fn get_diff(&self, cursor: &Cursor, diff: &Diff, reverse: bool) -> orfail::Result<Diff> {
         let Some((i, node)) = self.get_maybe_child(cursor).or_fail()? else {
             return Ok(diff.clone());
         };
@@ -495,7 +495,7 @@ impl DiffTreeNode {
             return Ok(chunk.to_diff(path));
         };
 
-        Ok(chunk.get_line_chunk(i, stage).or_fail()?.to_diff(path))
+        Ok(chunk.get_line_chunk(i, reverse).or_fail()?.to_diff(path))
     }
 
     fn cursor_right(&self, cursor: &Cursor) -> Option<Cursor> {


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes several changes to the `src/diff.rs` and `src/widget_diff_tree.rs` files, focusing on renaming the `stage` parameter to `reverse` and updating related logic accordingly.

Changes in `src/diff.rs`:

* Renamed the `stage` parameter to `reverse` in the `get_line_chunk` method and updated the method logic to reflect this change.
* Updated the conditional checks within the `get_line_chunk` method to use `reverse` instead of `stage`.
* Modified the logic to determine the starting line number based on the `reverse` parameter.

Changes in `src/widget_diff_tree.rs`:

* Renamed the `stage` parameter to `reverse` in the `get_diff` method and updated the method logic accordingly. [[1]](diffhunk://#diff-9660ae0b7247c099abfd79b3f6311350dd54fc45ac8ab36ea463e9d429763234L477-R482) [[2]](diffhunk://#diff-9660ae0b7247c099abfd79b3f6311350dd54fc45ac8ab36ea463e9d429763234L498-R498)
* Updated the `stage` and `unstage` methods to pass the correct boolean value to the `get_diff` method based on the new `reverse` parameter. [[1]](diffhunk://#diff-9660ae0b7247c099abfd79b3f6311350dd54fc45ac8ab36ea463e9d429763234L465-R465) [[2]](diffhunk://#diff-9660ae0b7247c099abfd79b3f6311350dd54fc45ac8ab36ea463e9d429763234L477-R482)