### PR TITLE
Add handling for content changes in rename entries

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -337,6 +337,7 @@ pub enum FileDiff {
         old_path: PathBuf,
         new_path: PathBuf,
         similarity_index: SimilarityIndexHeaderLine,
+        // TODO: Add content
     },
     Chmod {
         path: PathBuf,
@@ -1047,6 +1048,26 @@ index 0000000..684e22a
         let diff = Diff::from_str(text).or_fail()?;
         assert_eq!(diff.files.len(), 1);
         assert!(matches!(diff.files[0], FileDiff::New { .. }));
+
+        let text = r#"diff --git a/src/foo_file.rs b/src/foo.rs
+similarity index 96%
+rename from src/foo_file.rs
+rename to src/foo.rs
+index d33f81c..fce276a 100644
+--- a/src/foo_file.rs
++++ b/src/foo.rs
+@@ -9,7 +9,7 @@ use serde::Deserialize;
+ use crate;
+
+ #[derive(Debug, Clone, Deserialize)]
+-pub struct Foo {
++pub struct FooMetadata {
+     #[serde(default)]
+     pub bar: bool,
+     pub baz: bool,"#;
+        let diff = Diff::from_str(text).or_fail()?;
+        assert_eq!(diff.files.len(), 1);
+        assert!(matches!(diff.files[0], FileDiff::Rename { .. }));
 
         Ok(())
     }

--- a/src/widget_diff_tree.rs
+++ b/src/widget_diff_tree.rs
@@ -630,11 +630,30 @@ impl DiffTreeNodeContent for FileDiff {
                     },
                 ]
             }
-            FileDiff::Rename { old_path, .. } => {
+            FileDiff::Rename {
+                old_path, content, ..
+            } => {
                 let old_path =
                     Token::with_style(old_path.display().to_string(), TokenStyle::Underlined);
 
-                vec![Token::new("renamed "), old_path, Token::new(" -> "), path]
+                let summary = if content.is_some() {
+                    Token::new(format!(
+                        " ({} chunks, -{} +{} lines)",
+                        self.children().len(),
+                        self.removed_lines(),
+                        self.added_lines(),
+                    ))
+                } else {
+                    Token::new("")
+                };
+
+                vec![
+                    Token::new("renamed "),
+                    old_path,
+                    Token::new(" -> "),
+                    path,
+                    summary,
+                ]
             }
             FileDiff::Delete { content, .. } => {
                 vec![


### PR DESCRIPTION
Copilot Summary
-----------------------------

This pull request includes several updates to the `src/diff.rs` file to enhance the handling of file diffs, particularly for renamed files. The changes ensure that content diffs are correctly processed and displayed for various file operations. The most important changes include adding content handling for renamed files, updating the `FileDiff` enum, and modifying the `impl FileDiff` methods to support these enhancements.

Enhancements to file diff handling:

* [`src/diff.rs`](diffhunk://#diff-25b61929ffc58aa6b4baa8b06a41448eb83835e05c325863e58df00ed841b2d4L188-R189): Modified `ChunkDiff` to provide a more descriptive error message when encountering an unexpected diff line.
* [`src/diff.rs`](diffhunk://#diff-25b61929ffc58aa6b4baa8b06a41448eb83835e05c325863e58df00ed841b2d4R341): Updated the `FileDiff` enum to include an optional `content` field for renamed files.
* [`src/diff.rs`](diffhunk://#diff-25b61929ffc58aa6b4baa8b06a41448eb83835e05c325863e58df00ed841b2d4L377-R383): Enhanced the `chunks` method in `impl FileDiff` to handle content for renamed files.
* [`src/diff.rs`](diffhunk://#diff-25b61929ffc58aa6b4baa8b06a41448eb83835e05c325863e58df00ed841b2d4L425-R431): Added content parsing logic for renamed files in the `parse_with_similarity_index` method. [[1]](diffhunk://#diff-25b61929ffc58aa6b4baa8b06a41448eb83835e05c325863e58df00ed841b2d4L425-R431) [[2]](diffhunk://#diff-25b61929ffc58aa6b4baa8b06a41448eb83835e05c325863e58df00ed841b2d4R440-R460)

Improvement to diff summary display:

* [`src/widget_diff_tree.rs`](diffhunk://#diff-9660ae0b7247c099abfd79b3f6311350dd54fc45ac8ab36ea463e9d429763234L633-R656): Updated the `DiffTreeNodeContent` implementation for `FileDiff` to include a summary of content changes for renamed files.