### PR TITLE
Add handling for new files that cannot be read using `std::fs::read()`

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -78,9 +78,8 @@ pub fn unstaged_and_staged_diffs() -> orfail::Result<(Diff, Diff)> {
         let mut handles = Vec::new();
         for path in &untracked_files {
             handles.push(s.spawn(move || {
-                let content = std::fs::read(path)
-                    .or_fail_with(|e| format!("failed to read file {:?}: {e}", path.display()))?;
-                if std::str::from_utf8(&content).is_ok() {
+                let content = std::fs::read(path).ok();
+                if content.is_some_and(|c| std::str::from_utf8(&c).is_ok()) {
                     let diff = new_file_diff(path, false).or_fail()?;
                     FileDiff::from_str(&diff).or_fail()
                 } else {


### PR DESCRIPTION
Copilot Summary
----------------------------

This pull request includes a small but important change to the `unstaged_and_staged_diffs` function in the `src/git.rs` file. The change improves error handling when reading untracked files.

* [`src/git.rs`](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5L81-R82): Modified the `unstaged_and_staged_diffs` function to use `ok()` and `is_some_and` for error handling when reading untracked files, replacing the previous approach that used `or_fail_with`.