### PR TITLE
Fix an error when staging the deletion of binary files

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -576,7 +576,7 @@ impl FileDiff {
                 ..
             } => {
                 if let ContentDiff::Binary = content {
-                    let diff = git::new_file_diff(path, true).or_fail()?;
+                    let diff = git::binary_file_diff(path).or_fail()?;
                     patch.push_str(&diff);
                 } else {
                     let path = path.display();

--- a/src/git.rs
+++ b/src/git.rs
@@ -111,9 +111,9 @@ pub fn unstaged_and_staged_diffs() -> orfail::Result<(Diff, Diff)> {
 
 pub fn binary_file_diff<P: AsRef<Path>>(path: P) -> orfail::Result<String> {
     let path = &path.as_ref().display().to_string();
-    let diff = call(&["diff", "--binary", path], true).or_fail()?;
+    let diff = call(&["diff", "--binary", "--", path], true).or_fail()?;
     if diff.is_empty() {
-        call(&["diff", "--binary", "--cached", path], true).or_fail()
+        call(&["diff", "--binary", "--cached", "--", path], true).or_fail()
     } else {
         Ok(diff)
     }


### PR DESCRIPTION
Copilot Summary 
---

This pull request includes changes to the way binary file diffs are handled in the `src/diff.rs` and `src/git.rs` files. The updates aim to improve the accuracy and reliability of generating binary file diffs by modifying the method calls and parameters.

Changes to binary file diff handling:

* [`src/diff.rs`](diffhunk://#diff-25b61929ffc58aa6b4baa8b06a41448eb83835e05c325863e58df00ed841b2d4L579-R579): Updated the `FileDiff` implementation to use the `binary_file_diff` method instead of `new_file_diff` for binary content diffs.
* [`src/git.rs`](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5L114-R116): Modified the `binary_file_diff` function to include an additional `--` parameter in the `diff` command to ensure proper handling of file paths and to differentiate between staged and unstaged changes.