### PR TITLE
Fix issue where stage action is ignored when mamediff runs outside a Git top-level directory 

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -11,10 +11,10 @@ use crate::diff::{ContentDiff, Diff, FileDiff, Mode};
 
 pub fn is_available() -> bool {
     // Check if `git` is accessible and we are within a Git directory.
-    call(&["rev-parse", "--is-inside-work-tree"], true)
-        .ok()
-        .filter(|s| s.trim() == "true")
-        .is_some()
+    let Ok(root_dir) = call(&["rev-parse", "--show-toplevel"], true) else {
+        return false;
+    };
+    std::env::set_current_dir(root_dir.trim()).is_ok()
 }
 
 pub fn stage(diff: &Diff) -> orfail::Result<()> {


### PR DESCRIPTION
Copilot Summary 
---

This pull request includes a change to the `src/git.rs` file to improve the method for checking if the current directory is a Git repository. The most important change is the modification of the `is_available` function to use a different Git command and handle the current directory more robustly.

Changes to Git directory check:

* [`src/git.rs`](diffhunk://#diff-61336e02d0e3f7f4aa9477a992611ead7af693235398ac276a93b229e317abf5L14-R17): Modified the `is_available` function to use the `rev-parse --show-toplevel` command and set the current directory to the root of the Git repository. This change improves the reliability of checking if the current directory is within a Git repository.