### PR TITLE
Add vim movement keys

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -109,7 +109,7 @@ impl App {
                     self.render().or_fail()?;
                 }
             }
-            KeyCode::Up => {
+            KeyCode::Up | KeyCode::Char('k') => {
                 if self.tree.cursor_up().or_fail()? {
                     self.scroll_if_need();
                     self.render().or_fail()?;
@@ -121,7 +121,7 @@ impl App {
                     self.render().or_fail()?;
                 }
             }
-            KeyCode::Down => {
+            KeyCode::Down | KeyCode::Char('j') => {
                 if self.tree.cursor_down().or_fail()? {
                     self.scroll_if_need();
                     self.render().or_fail()?;
@@ -133,7 +133,7 @@ impl App {
                     self.render().or_fail()?;
                 }
             }
-            KeyCode::Right => {
+            KeyCode::Right | KeyCode::Char('l') => {
                 if self.tree.cursor_right().or_fail()? {
                     self.scroll_if_need();
                     self.render().or_fail()?;
@@ -145,7 +145,7 @@ impl App {
                     self.render().or_fail()?;
                 }
             }
-            KeyCode::Left => {
+            KeyCode::Left | KeyCode::Char('h') => {
                 if self.tree.cursor_left() {
                     self.scroll_if_need();
                     self.render().or_fail()?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -99,7 +99,7 @@ impl App {
                     self.render().or_fail()?;
                 }
             }
-            KeyCode::Char('h') => {
+            KeyCode::Char('H') => {
                 self.legend.toggle_hide();
                 self.render().or_fail()?;
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -74,92 +74,61 @@ impl App {
         }
 
         let ctrl = event.modifiers.contains(KeyModifiers::CONTROL);
-        match event.code {
-            KeyCode::Char('q') | KeyCode::Esc => {
+        match (ctrl, event.code) {
+            (false, KeyCode::Char('q') | KeyCode::Esc) | (true, KeyCode::Char('c')) => {
                 self.exit = true;
             }
-            KeyCode::Char('c') if ctrl => {
-                self.exit = true;
-            }
-            KeyCode::Char('u') => {
+            (false, KeyCode::Char('u')) => {
                 if self.tree.unstage().or_fail()? {
                     self.scroll_if_need();
                     self.render().or_fail()?;
                 }
             }
-            KeyCode::Char('s') => {
+            (false, KeyCode::Char('s')) => {
                 if self.tree.stage().or_fail()? {
                     self.scroll_if_need();
                     self.render().or_fail()?;
                 }
             }
-            KeyCode::Char('D') => {
+            (false, KeyCode::Char('D')) => {
                 if self.tree.discard().or_fail()? {
                     self.scroll_if_need();
                     self.render().or_fail()?;
                 }
             }
-            KeyCode::Char('H') => {
+            (false, KeyCode::Char('H')) => {
                 self.legend.toggle_hide();
                 self.render().or_fail()?;
             }
-            KeyCode::Char('p') if ctrl => {
+            (true, KeyCode::Char('p')) | (false, KeyCode::Up | KeyCode::Char('k')) => {
                 if self.tree.cursor_up().or_fail()? {
                     self.scroll_if_need();
                     self.render().or_fail()?;
                 }
             }
-            KeyCode::Up | KeyCode::Char('k') => {
-                if self.tree.cursor_up().or_fail()? {
-                    self.scroll_if_need();
-                    self.render().or_fail()?;
-                }
-            }
-            KeyCode::Char('n') if ctrl => {
+            (true, KeyCode::Char('n')) | (false, KeyCode::Down | KeyCode::Char('j')) => {
                 if self.tree.cursor_down().or_fail()? {
                     self.scroll_if_need();
                     self.render().or_fail()?;
                 }
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if self.tree.cursor_down().or_fail()? {
-                    self.scroll_if_need();
-                    self.render().or_fail()?;
-                }
-            }
-            KeyCode::Char('f') if ctrl => {
+            (true, KeyCode::Char('f')) | (false, KeyCode::Right | KeyCode::Char('l')) => {
                 if self.tree.cursor_right().or_fail()? {
                     self.scroll_if_need();
                     self.render().or_fail()?;
                 }
             }
-            KeyCode::Right | KeyCode::Char('l') => {
-                if self.tree.cursor_right().or_fail()? {
-                    self.scroll_if_need();
-                    self.render().or_fail()?;
-                }
-            }
-            KeyCode::Char('b') if ctrl => {
+            (true, KeyCode::Char('b')) | (false, KeyCode::Left | KeyCode::Char('h')) => {
                 if self.tree.cursor_left() {
                     self.scroll_if_need();
                     self.render().or_fail()?;
                 }
             }
-            KeyCode::Left | KeyCode::Char('h') => {
-                if self.tree.cursor_left() {
-                    self.scroll_if_need();
-                    self.render().or_fail()?;
-                }
-            }
-            KeyCode::Char('t') | KeyCode::Tab => {
+            (false, KeyCode::Char('t') | KeyCode::Tab) => {
                 self.tree.toggle().or_fail()?;
                 self.render().or_fail()?;
             }
-            KeyCode::Char('r') => {
-                self.recenter();
-                self.render().or_fail()?;
-            }
-            KeyCode::Char('l') if ctrl => {
+            (false, KeyCode::Char('r')) | (true, KeyCode::Char('l')) => {
                 self.recenter();
                 self.render().or_fail()?;
             }

--- a/src/widget_legend.rs
+++ b/src/widget_legend.rs
@@ -21,7 +21,7 @@ impl LegendWidget {
         if self.hide {
             let col = canvas.frame_size().cols - Self::HIDE_COLS;
             canvas.set_col_offset(col);
-            canvas.drawln(Token::new("+- s(h)ow -"));
+            canvas.drawln(Token::new("+- s(H)ow -"));
         } else {
             let col = canvas.frame_size().cols - Self::SHOW_COLS;
             canvas.set_col_offset(col);
@@ -53,7 +53,7 @@ impl LegendWidget {
             if tree.can_unstage() {
                 canvas.drawln(Token::new("| (u)nstage       "));
             }
-            canvas.drawln(Token::new("+---- (h)ide -----"));
+            canvas.drawln(Token::new("+---- (H)ide -----"));
         }
     }
 

--- a/src/widget_legend.rs
+++ b/src/widget_legend.rs
@@ -30,16 +30,16 @@ impl LegendWidget {
                 canvas.drawln(Token::new("| (r)ecenter [C-l]"));
             }
             if tree.can_cursor_up() {
-                canvas.drawln(Token::new("| (↑)        [C-p]"));
+                canvas.drawln(Token::new("| (↑)      [k,C-p]"));
             }
             if tree.can_cursor_down() {
-                canvas.drawln(Token::new("| (↓)        [C-n]"));
+                canvas.drawln(Token::new("| (↓)      [j,C-n]"));
             }
             if tree.can_cursor_left() {
-                canvas.drawln(Token::new("| (←)        [C-b]"));
+                canvas.drawln(Token::new("| (←)      [h,C-b]"));
             }
             if tree.can_cursor_right() {
-                canvas.drawln(Token::new("| (→)        [C-f]"));
+                canvas.drawln(Token::new("| (→)      [l,C-f]"));
             }
             if tree.can_toggle() {
                 canvas.drawln(Token::new("| (t)oggle   [TAB]"));


### PR DESCRIPTION
Close #8 

Copilot Summary
-----

This pull request focuses on improving the handling of key events and updating the legend widget display in the `src/app.rs` and `src/widget_legend.rs` files. The changes streamline the code and enhance the user interface by making key bindings more consistent and visible.

Key event handling improvements:

* [`src/app.rs`](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L77-R131): Consolidated key event matches to handle both control and non-control key events in a more unified manner. This reduces redundancy and makes the code easier to maintain.

Legend widget display updates:

* [`src/widget_legend.rs`](diffhunk://#diff-e8462790013c998452ceea282a59a08167ee3ae667169ae1f0753371fc840bcbL24-R24): Updated the legend widget to reflect the new key bindings, ensuring that users can see the correct key combinations for various actions. [[1]](diffhunk://#diff-e8462790013c998452ceea282a59a08167ee3ae667169ae1f0753371fc840bcbL24-R24) [[2]](diffhunk://#diff-e8462790013c998452ceea282a59a08167ee3ae667169ae1f0753371fc840bcbL33-R42) [[3]](diffhunk://#diff-e8462790013c998452ceea282a59a08167ee3ae667169ae1f0753371fc840bcbL56-R56)