### PR TITLE
Add active binding highlighting support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "mame"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3851eafd59d042ceb744c75a83e4b7510d47e69d305dca6f8115369f79378468"
+checksum = "fe53f56fcd1c85b4746088eee9e55b4f54d56ecf85f6916ef282ebbd428ae2b1"
 dependencies = [
  "nojson",
  "tuinix",
@@ -85,9 +85,9 @@ checksum = "fe77e710319d3ff009f93efc433d879e80e6336f5b87ace6d6db7ca5951085c3"
 
 [[package]]
 name = "nojson"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a847c0a03d7915f0e8c1e4ecf3ab97f8523fd703eadb79582bfb464bb224bab2"
+checksum = "20f9facf70a088279ffcf06cb5f897660ebd32621629b51872f4d4b25c77e494"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "mame"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8b83daad11b52a6cbded06faa2f0a1db2d4b64c16ef5634e501a6e0735cf9c"
+checksum = "3851eafd59d042ceb744c75a83e4b7510d47e69d305dca6f8115369f79378468"
 dependencies = [
  "nojson",
  "tuinix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "mame"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe53f56fcd1c85b4746088eee9e55b4f54d56ecf85f6916ef282ebbd428ae2b1"
+checksum = "831e4b14f0f5d8a17a02172fbded90df0d8447d8061b5de859212461548f23c6"
 dependencies = [
  "nojson",
  "tuinix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 categories = ["command-line-utilities"]
 
 [dependencies]
-mame = "0.2.1"
+mame = "0.2.2"
 noargs = "0.4.1"
-nojson = "0.3.4"
+nojson = "0.3.6"
 orfail = "1.1.0"
 tuinix = "0.3.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 categories = ["command-line-utilities"]
 
 [dependencies]
-mame = "0.2.0"
+mame = "0.2.1"
 noargs = "0.4.1"
 nojson = "0.3.4"
 orfail = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 categories = ["command-line-utilities"]
 
 [dependencies]
-mame = "0.2.2"
+mame = "0.2.3"
 noargs = "0.4.1"
 nojson = "0.3.6"
 orfail = "1.1.0"

--- a/configs/sile.jsonc
+++ b/configs/sile.jsonc
@@ -21,6 +21,7 @@
       "type": "init-legend",
       "hide": {"ref": "MAMEDIFF_HIDE_LEGEND"},
       "labels": {"show": "s(h)ow", "hide": "(h)ide"},
+      "highlight_active": true,
     },
   },
   "bindings": {

--- a/configs/sile.jsonc
+++ b/configs/sile.jsonc
@@ -21,7 +21,7 @@
       "type": "init-legend",
       "hide": {"ref": "MAMEDIFF_HIDE_LEGEND"},
       "labels": {"show": "s(h)ow", "hide": "(h)ide"},
-      "highlight_active": true,
+      "highlight_active_binding": true,
     },
   },
   "bindings": {

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,7 +1,5 @@
 use crate::widget_diff_tree::DiffTreeWidget;
 
-pub type ActionBindingSystem = mame::action::ActionBindingSystem<Action>;
-
 #[derive(Debug, Clone)]
 pub enum Action {
     Quit,

--- a/src/action.rs
+++ b/src/action.rs
@@ -17,7 +17,7 @@ pub enum Action {
         hide: bool,
         label_show: String,
         label_hide: String,
-        highlight_active: bool,
+        highlight_active_binding: bool,
     },
     ExecuteCommand(mame::command::ExternalCommand),
 }

--- a/src/action.rs
+++ b/src/action.rs
@@ -19,6 +19,7 @@ pub enum Action {
         hide: bool,
         label_show: String,
         label_hide: String,
+        highlight_active: bool,
     },
     ExecuteCommand(mame::command::ExternalCommand),
 }
@@ -68,6 +69,10 @@ impl<'text, 'raw> TryFrom<nojson::RawJsonValue<'text, 'raw>> for Action {
                     .to_member("hide")?
                     .map(bool::try_from)?
                     .unwrap_or_default();
+                let highlight_active = value
+                    .to_member("highlight_active")?
+                    .map(bool::try_from)?
+                    .unwrap_or_default();
                 let labels = value.to_member("labels")?.required()?;
                 let label_show = labels.to_member("show")?.required()?.try_into()?;
                 let label_hide = labels.to_member("hide")?.required()?.try_into()?;
@@ -75,6 +80,7 @@ impl<'text, 'raw> TryFrom<nojson::RawJsonValue<'text, 'raw>> for Action {
                     hide,
                     label_show,
                     label_hide,
+                    highlight_active,
                 })
             }
             "execute-command" => Ok(Self::ExecuteCommand(value.try_into()?)),

--- a/src/action.rs
+++ b/src/action.rs
@@ -67,8 +67,8 @@ impl<'text, 'raw> TryFrom<nojson::RawJsonValue<'text, 'raw>> for Action {
                     .to_member("hide")?
                     .map(bool::try_from)?
                     .unwrap_or_default();
-                let highlight_active = value
-                    .to_member("highlight_active")?
+                let highlight_active_binding = value
+                    .to_member("highlight_active_binding")?
                     .map(bool::try_from)?
                     .unwrap_or_default();
                 let labels = value.to_member("labels")?.required()?;
@@ -78,7 +78,7 @@ impl<'text, 'raw> TryFrom<nojson::RawJsonValue<'text, 'raw>> for Action {
                     hide,
                     label_show,
                     label_hide,
-                    highlight_active,
+                    highlight_active_binding,
                 })
             }
             "execute-command" => Ok(Self::ExecuteCommand(value.try_into()?)),

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,7 +38,7 @@ impl App {
 
     pub fn run(mut self) -> orfail::Result<()> {
         if let Some(action) = self.config.setup_action().cloned() {
-            self.handle_action(&action).or_fail()?;
+            self.handle_action(action).or_fail()?;
         }
         self.render().or_fail()?;
 
@@ -96,7 +96,7 @@ impl App {
                         if self.legend.highlight_active {
                             self.render().or_fail()?;
                         }
-                        self.handle_action(&action).or_fail()?;
+                        self.handle_action(action).or_fail()?;
                     }
                     self.current_binding_index = None;
 
@@ -111,7 +111,7 @@ impl App {
         }
     }
 
-    fn handle_action(&mut self, action: &Action) -> orfail::Result<()> {
+    fn handle_action(&mut self, action: Action) -> orfail::Result<()> {
         match action {
             Action::Quit => {
                 self.exit = true;
@@ -166,10 +166,10 @@ impl App {
                 label_hide,
                 highlight_active,
             } => {
-                self.legend.label_show = label_show.clone();
-                self.legend.label_hide = label_hide.clone();
-                self.legend.hide = *hide;
-                self.legend.highlight_active = *highlight_active;
+                self.legend.label_show = label_show;
+                self.legend.label_hide = label_hide;
+                self.legend.hide = hide;
+                self.legend.highlight_active = highlight_active;
             }
             Action::ExecuteCommand(a) => {
                 self.execute_command(&a).or_fail()?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -84,14 +84,13 @@ impl App {
                     && let Some(action) = binding.action.clone()
                 {
                     if self.legend.highlight_active {
-                        self.legend.ongoing_binding_id = Some(binding.id);
                         self.render().or_fail()?;
                     }
 
                     self.handle_action(action).or_fail()?;
-                    self.legend.ongoing_binding_id = None;
                 }
-                if self.bindings.last_binding_id().is_some() {
+                if self.bindings.last_binding().is_some() {
+                    self.bindings.apply_last_context_switch();
                     self.render().or_fail()?;
                 }
                 Ok(())

--- a/src/app.rs
+++ b/src/app.rs
@@ -152,7 +152,9 @@ impl App {
                 label_show,
                 label_hide,
             } => {
-                self.legend.init(label_show, label_hide, hide);
+                self.legend.label_show = label_show;
+                self.legend.label_hide = label_hide;
+                self.legend.hide = hide;
             }
             Action::ExecuteCommand(a) => {
                 self.execute_command(&a).or_fail()?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,17 +1,17 @@
+use mame::action::{BindingConfig, BindingContextName};
 use orfail::OrFail;
 use tuinix::{Terminal, TerminalEvent};
 
 use crate::{
-    action::{Action, ActionBindingSystem},
-    canvas::Canvas,
-    widget_diff_tree::DiffTreeWidget,
-    widget_legend::LegendWidget,
+    action::Action, canvas::Canvas, widget_diff_tree::DiffTreeWidget, widget_legend::LegendWidget,
 };
 
 #[derive(Debug)]
 pub struct App {
     terminal: Terminal,
-    bindings: ActionBindingSystem,
+    config: BindingConfig<Action>,
+    context: BindingContextName,
+    current_binding_index: Option<usize>,
     exit: bool,
     frame_row_start: usize,
     tree: DiffTreeWidget,
@@ -20,12 +20,14 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(bindings: ActionBindingSystem) -> orfail::Result<Self> {
+    pub fn new(config: BindingConfig<Action>) -> orfail::Result<Self> {
         let terminal = Terminal::new().or_fail()?;
         let tree = DiffTreeWidget::new(terminal.size()).or_fail()?;
         Ok(Self {
             terminal,
-            bindings,
+            context: config.initial_context().clone(),
+            config,
+            current_binding_index: None,
             exit: false,
             frame_row_start: 0,
             tree,
@@ -35,7 +37,7 @@ impl App {
     }
 
     pub fn run(mut self) -> orfail::Result<()> {
-        if let Some(action) = self.bindings.setup_action().cloned() {
+        if let Some(action) = self.config.setup_action().cloned() {
             self.handle_action(&action).or_fail()?;
         }
         self.render().or_fail()?;
@@ -62,9 +64,11 @@ impl App {
         if let Some(preview) = &mut self.preview {
             preview.render(&mut frame).or_fail()?;
         }
-        self.legend
-            .render(&mut frame, &self.bindings, &self.tree)
-            .or_fail()?;
+        if let Some(bindings) = self.config.get_bindings(&self.context) {
+            self.legend
+                .render(&mut frame, bindings, self.current_binding_index, &self.tree)
+                .or_fail()?;
+        }
 
         self.terminal.draw(frame).or_fail()?;
 
@@ -80,19 +84,24 @@ impl App {
                 self.render().or_fail()
             }
             TerminalEvent::Input(input) => {
-                if let Some(binding) = self.bindings.handle_input(input) {
-                    self.legend.current_binding = Some(binding.clone());
-                    if let Some(action) = &binding.action {
+                if let Some(bindings) = self.config.get_bindings(&self.context)
+                    && let Some((index, binding)) =
+                        bindings.iter().enumerate().find(|(_, b)| b.matches(input))
+                {
+                    let next_context = binding.context.clone();
+                    let action = binding.action.clone();
+
+                    self.current_binding_index = Some(index);
+                    if let Some(action) = action {
                         if self.legend.highlight_active {
                             self.render().or_fail()?;
                         }
-
-                        self.handle_action(action).or_fail()?;
+                        self.handle_action(&action).or_fail()?;
                     }
-                }
-                if let Some(binding) = self.legend.current_binding.take() {
-                    if let Some(context) = &binding.context {
-                        self.bindings.set_current_context(context);
+                    self.current_binding_index = None;
+
+                    if let Some(context) = next_context {
+                        self.context = context;
                     }
                     self.render().or_fail()?;
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -83,8 +83,10 @@ impl App {
                 if let Some(binding) = self.bindings.handle_input(input)
                     && let Some(action) = binding.action.clone()
                 {
-                    self.legend.ongoing_binding_id = Some(binding.id);
-                    self.render().or_fail()?;
+                    if self.legend.highlight_active {
+                        self.legend.ongoing_binding_id = Some(binding.id);
+                        self.render().or_fail()?;
+                    }
 
                     self.handle_action(action).or_fail()?;
                     self.legend.ongoing_binding_id = None;

--- a/src/app.rs
+++ b/src/app.rs
@@ -92,7 +92,7 @@ impl App {
                     let action = binding.action.clone();
 
                     if let Some(action) = action {
-                        if self.legend.highlight_active {
+                        if self.legend.highlight_active_binding {
                             self.current_binding_index = Some(index);
                             self.render().or_fail()?;
                             self.current_binding_index = None;
@@ -164,12 +164,12 @@ impl App {
                 hide,
                 label_show,
                 label_hide,
-                highlight_active,
+                highlight_active_binding,
             } => {
                 self.legend.label_show = label_show;
                 self.legend.label_hide = label_hide;
                 self.legend.hide = hide;
-                self.legend.highlight_active = highlight_active;
+                self.legend.highlight_active_binding = highlight_active_binding;
             }
             Action::ExecuteCommand(a) => {
                 self.execute_command(&a).or_fail()?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -91,14 +91,14 @@ impl App {
                     let next_context = binding.context.clone();
                     let action = binding.action.clone();
 
-                    self.current_binding_index = Some(index);
                     if let Some(action) = action {
                         if self.legend.highlight_active {
+                            self.current_binding_index = Some(index);
                             self.render().or_fail()?;
+                            self.current_binding_index = None;
                         }
                         self.handle_action(action).or_fail()?;
                     }
-                    self.current_binding_index = None;
 
                     if let Some(context) = next_context {
                         self.context = context;

--- a/src/app.rs
+++ b/src/app.rs
@@ -151,10 +151,12 @@ impl App {
                 hide,
                 label_show,
                 label_hide,
+                highlight_active,
             } => {
                 self.legend.label_show = label_show;
                 self.legend.label_hide = label_hide;
                 self.legend.hide = hide;
+                self.legend.highlight_active = highlight_active;
             }
             Action::ExecuteCommand(a) => {
                 self.execute_command(&a).or_fail()?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -84,9 +84,9 @@ impl App {
                 self.render().or_fail()
             }
             TerminalEvent::Input(input) => {
-                if let Some(bindings) = self.config.get_bindings(&self.context)
-                    && let Some((index, binding)) =
-                        bindings.iter().enumerate().find(|(_, b)| b.matches(input))
+                let bindings = self.config.get_bindings(&self.context).or_fail()?;
+                if let Some((index, binding)) =
+                    bindings.iter().enumerate().find(|(_, b)| b.matches(input))
                 {
                     let next_context = binding.context.clone();
                     let action = binding.action.clone();

--- a/src/app.rs
+++ b/src/app.rs
@@ -83,7 +83,11 @@ impl App {
                 if let Some(binding) = self.bindings.handle_input(input)
                     && let Some(action) = binding.action.clone()
                 {
+                    self.legend.ongoing_binding_id = Some(binding.id);
+                    self.render().or_fail()?;
+
                     self.handle_action(action).or_fail()?;
+                    self.legend.ongoing_binding_id = None;
                 }
                 if self.bindings.last_binding_id().is_some() {
                     self.render().or_fail()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
-use mamediff::{action::ActionBindingSystem, app::App, git};
+use mame::action::BindingConfig;
+use mamediff::{app::App, git};
 use orfail::OrFail;
 
 fn main() -> noargs::Result<()> {
@@ -37,13 +38,13 @@ fn main() -> noargs::Result<()> {
         std::process::exit(1);
     };
 
-    let bindings = if let Some(path) = config_path {
-        ActionBindingSystem::load_from_file(path)?
+    let config = if let Some(path) = config_path {
+        BindingConfig::load_from_file(path)?
     } else {
-        ActionBindingSystem::load_from_str("<DEFAULT>", include_str!("../configs/default.jsonc"))?
+        BindingConfig::load_from_str("<DEFAULT>", include_str!("../configs/default.jsonc"))?
     };
 
-    let app = App::new(bindings).or_fail()?;
+    let app = App::new(config).or_fail()?;
     app.run().or_fail()?;
     Ok(())
 }

--- a/src/widget_legend.rs
+++ b/src/widget_legend.rs
@@ -8,7 +8,7 @@ pub struct LegendWidget {
     pub label_show: String,
     pub label_hide: String,
     pub hide: bool,
-    pub highlight_active: bool,
+    pub highlight_active_binding: bool,
 }
 
 impl LegendWidget {
@@ -30,7 +30,8 @@ impl LegendWidget {
                     .filter(|(_, b)| b.action.as_ref().is_some_and(|a| a.is_applicable(tree)))
                     .filter_map(|(i, b)| {
                         let label = b.label.as_ref()?;
-                        let highlight = self.highlight_active && Some(i) == current_binding_index;
+                        let highlight =
+                            self.highlight_active_binding && Some(i) == current_binding_index;
                         Some(if highlight {
                             let bold = tuinix::TerminalStyle::new().bold();
                             let reset = tuinix::TerminalStyle::RESET;

--- a/src/widget_legend.rs
+++ b/src/widget_legend.rs
@@ -3,9 +3,9 @@ use crate::widget_diff_tree::DiffTreeWidget;
 
 #[derive(Debug, Default)]
 pub struct LegendWidget {
-    label_show: String,
-    label_hide: String,
-    hide: bool,
+    pub label_show: String,
+    pub label_hide: String,
+    pub hide: bool,
     pub ongoing_binding_id: Option<mame::action::BindingId>,
 }
 
@@ -39,12 +39,6 @@ impl LegendWidget {
         };
         legend.render(frame)?;
         Ok(())
-    }
-
-    pub fn init(&mut self, label_show: String, label_hide: String, hide: bool) {
-        self.label_show = label_show;
-        self.label_hide = label_hide;
-        self.hide = hide;
     }
 
     pub fn toggle_hide(&mut self) {

--- a/src/widget_legend.rs
+++ b/src/widget_legend.rs
@@ -6,6 +6,7 @@ pub struct LegendWidget {
     label_show: String,
     label_hide: String,
     hide: bool,
+    pub ongoing_binding_id: Option<mame::action::InputBindingId>,
 }
 
 impl LegendWidget {
@@ -24,8 +25,16 @@ impl LegendWidget {
                     .current_bindings()
                     .iter()
                     .filter(|b| b.action.as_ref().is_some_and(|a| a.is_applicable(tree)))
-                    .filter_map(|b| b.label.as_ref())
-                    .map(|s| format!(" {s}")),
+                    .filter_map(|b| {
+                        let label = b.label.as_ref()?;
+                        Some(if self.ongoing_binding_id == Some(b.id) {
+                            let bold = tuinix::TerminalStyle::new().bold();
+                            let reset = tuinix::TerminalStyle::RESET;
+                            format!(" {bold}{label}{reset}")
+                        } else {
+                            format!(" {label}")
+                        })
+                    }),
             )
         };
         legend.render(frame)?;

--- a/src/widget_legend.rs
+++ b/src/widget_legend.rs
@@ -1,4 +1,8 @@
-use crate::action::ActionBindingSystem;
+use std::sync::Arc;
+
+use mame::action::Binding;
+
+use crate::action::{Action, ActionBindingSystem};
 use crate::widget_diff_tree::DiffTreeWidget;
 
 #[derive(Debug, Default)]
@@ -7,6 +11,7 @@ pub struct LegendWidget {
     pub label_hide: String,
     pub hide: bool,
     pub highlight_active: bool,
+    pub current_binding: Option<Arc<Binding<Action>>>,
 }
 
 impl LegendWidget {
@@ -27,7 +32,11 @@ impl LegendWidget {
                     .filter(|b| b.action.as_ref().is_some_and(|a| a.is_applicable(tree)))
                     .filter_map(|b| {
                         let label = b.label.as_ref()?;
-                        let highlight = self.highlight_active && bindings.is_last_binding(b);
+                        let highlight = self.highlight_active
+                            && self
+                                .current_binding
+                                .as_ref()
+                                .is_some_and(|binding| Arc::ptr_eq(binding, b));
                         Some(if highlight {
                             let bold = tuinix::TerminalStyle::new().bold();
                             let reset = tuinix::TerminalStyle::RESET;

--- a/src/widget_legend.rs
+++ b/src/widget_legend.rs
@@ -6,7 +6,7 @@ pub struct LegendWidget {
     label_show: String,
     label_hide: String,
     hide: bool,
-    pub ongoing_binding_id: Option<mame::action::InputBindingId>,
+    pub ongoing_binding_id: Option<mame::action::BindingId>,
 }
 
 impl LegendWidget {

--- a/src/widget_legend.rs
+++ b/src/widget_legend.rs
@@ -7,6 +7,7 @@ pub struct LegendWidget {
     pub label_hide: String,
     pub hide: bool,
     pub ongoing_binding_id: Option<mame::action::BindingId>,
+    pub highlight_active: bool,
 }
 
 impl LegendWidget {
@@ -27,7 +28,9 @@ impl LegendWidget {
                     .filter(|b| b.action.as_ref().is_some_and(|a| a.is_applicable(tree)))
                     .filter_map(|b| {
                         let label = b.label.as_ref()?;
-                        Some(if self.ongoing_binding_id == Some(b.id) {
+                        let highlight =
+                            self.highlight_active && self.ongoing_binding_id == Some(b.id);
+                        Some(if highlight {
                             let bold = tuinix::TerminalStyle::new().bold();
                             let reset = tuinix::TerminalStyle::RESET;
                             format!(" {bold}{label}{reset}")

--- a/src/widget_legend.rs
+++ b/src/widget_legend.rs
@@ -6,7 +6,6 @@ pub struct LegendWidget {
     pub label_show: String,
     pub label_hide: String,
     pub hide: bool,
-    pub ongoing_binding_id: Option<mame::action::BindingId>,
     pub highlight_active: bool,
 }
 
@@ -28,8 +27,7 @@ impl LegendWidget {
                     .filter(|b| b.action.as_ref().is_some_and(|a| a.is_applicable(tree)))
                     .filter_map(|b| {
                         let label = b.label.as_ref()?;
-                        let highlight =
-                            self.highlight_active && self.ongoing_binding_id == Some(b.id);
+                        let highlight = self.highlight_active && bindings.is_last_binding(b);
                         Some(if highlight {
                             let bold = tuinix::TerminalStyle::new().bold();
                             let reset = tuinix::TerminalStyle::RESET;


### PR DESCRIPTION
- **feat: add visual feedback for ongoing key bindings in legend**
- **chore: update mame dependency to 0.2.1**
- **refactor: remove init method and make legend fields public**
- **feat: add highlight_active option to toggle legend action**
- **feat: add highlight_active option to toggle legend action**
- **chore: update mame and nojson dependencies**
- **refactor: replace ongoing_binding_id with is_last_binding method**
- **refactor: improve binding reference handling and remove cloning**
- **refactor: migrate from ActionBindingSystem to BindingConfig API**
- **refactor: remove unnecessary cloning and borrowing in action handling**
- **chore: update mame dependency to 0.2.3**
- **refactor: simplify binding retrieval with or_fail pattern**
- **fix: only highlight binding when highlight_active is enabled**
- **refactor: rename highlight_active to highlight_active_binding**
- **refactor: rename highlight_active to highlight_active_binding**
